### PR TITLE
feat: add canonical skill management and validation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Participe da comunidade pelo link:
 
 A proposta do projeto é compartilhar uma base prática e instalável para que mais pessoas consigam configurar suas IAs com hierarquia, skills, hooks, documentação local e boas práticas de segurança, sem depender de uma configuração privada de uma máquina específica.
 
+## Requisitos e Compatibilidade
+
+Para garantir que o Orquestrador Maestro funcione corretamente em seu ambiente, verifique os requisitos mínimos:
+
+- **Windows**: PowerShell 4.0 ou superior (padrão no Windows 10/11; no Windows 7 SP1, requer a instalação do Windows Management Framework 4.0).
+- **Linux/macOS**: Bash 3.2 ou superior (padrão no macOS e na maioria das distribuições Linux).
+- **Sistemas Operacionais**: Windows 10/11, Linux (Ubuntu, Debian, CentOS, etc.) e macOS 10.15+.
+- **Node.js** (Opcional): Recomendado (versão 10.12.0 ou superior) para funções de gerenciamento, como criação de novas skills, validação do catálogo e sincronização dinâmica no Linux/macOS. O funcionamento básico das regras e skills já instaladas não depende do Node.js.
+
+Caso você esteja utilizando uma versão muito antiga de algum SO que não suporte esses requisitos, os scripts de instalação podem apresentar erros de sintaxe ou comandos não encontrados.
+
 ## Contribuição Da Comunidade
 
 O suporte Linux/macOS foi integrado a partir do fork [`kivervinicius/Orquestrador-Maestro`](https://github.com/kivervinicius/Orquestrador-Maestro), aberto na PR [#1 - feat: suporte multiplataforma (Linux/macOS)](https://github.com/FernandoBolzan/Orquestrador-Maestro/pull/1).
@@ -260,7 +271,7 @@ As skills canônicas ficam em `orquestrador/skills/` e são espelhadas para as p
 | `skill-ai-orchestration` | Estrutura uso server-side de IA: provedores, roteamento de modelos, fallback, filas, retries, tokens e observabilidade. |
 | `skill-multiagent-orchestration` | Divide trabalho independente entre agentes, define posse por arquivos e mantém integração final. |
 | `skill-aionui-cowork-orchestration` | Integra AionUi como camada de coordenação sem substituir Codex, skills, hooks e permissões locais. |
-| `skill-evolution-api` | Guia automação WhatsApp com Evolution API: instancias, QR, webhooks, consentimento, filas e rate limits. |
+| `skill-evolution-api` | Guia automação WhatsApp com Evolution API: instâncias, QR, webhooks, consentimento, filas e rate limits. |
 | `skill-frontend-ux-guardrails` | Aplica gates de UX: responsividade, overflow, acessibilidade, consistência visual e validação em telas. |
 | `skill-modern-ui-patterns` | Orienta UI SaaS/admin com React, TypeScript, Tailwind, estados de componentes e design system. |
 | `skill-open-design-ui` | Guia redesign visual, tokens, biblioteca de componentes e QA visual. |
@@ -274,6 +285,140 @@ As skills canônicas ficam em `orquestrador/skills/` e são espelhadas para as p
 As skills workflow do Codex/OMX ficam em `codex/skills/`. Elas cobrem execução, revisão, planejamento, delegação, diagnóstico, consulta a outros modelos e modos de trabalho como `ralph`, `team`, `ultrawork`, `deep-interview`, `code-review` e `security-review`.
 
 O catálogo completo está em [docs/skill-catalog.md](docs/skill-catalog.md).
+
+## Como Criar Uma Nova Skill
+
+Crie skills canônicas em `orquestrador/skills/` dentro deste repositório quando estiver evoluindo o snapshot público. Depois da instalação, a fonte canônica no computador do usuário fica em `%USERPROFILE%\.orquestrador\skills` no Windows ou `$HOME/.orquestrador/skills` no Linux/macOS.
+
+Não edite os espelhos diretamente (`.codex/skills`, `.claude/skills`, `.opencode/skills`, `.agents/skills`, etc.) a menos que esteja depurando. Eles são destinos de sincronização.
+
+### Exemplo: Skill De Front-End React
+
+No Windows, rode na raiz do repositório:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\new-canonical-skill.ps1 `
+  -Name "skill-react-frontend" `
+  -Description "Use for React front-end implementation and review, including component structure, hooks, state, forms, routing, accessibility, responsive layout, tests, and build verification." `
+  -Category "frontend" `
+  -Risk "medium" `
+  -Source "local-react-patterns" `
+  -Trigger "react frontend" `
+  -Trigger "react component" `
+  -Trigger "hooks react" `
+  -Trigger "frontend react" `
+  -Alias "react" `
+  -Alias "componente react" `
+  -Alias "front react" `
+  -MirrorEverywhere
+```
+
+No Linux/macOS:
+
+```bash
+./scripts/new-canonical-skill.sh \
+  --name skill-react-frontend \
+  --description "Use for React front-end implementation and review, including component structure, hooks, state, forms, routing, accessibility, responsive layout, tests, and build verification." \
+  --category frontend \
+  --risk medium \
+  --source local-react-patterns \
+  --trigger "react frontend" \
+  --trigger "react component" \
+  --trigger "hooks react" \
+  --trigger "frontend react" \
+  --alias react \
+  --alias "componente react" \
+  --alias "front react" \
+  --mirror-everywhere
+```
+
+Esse comando cria:
+
+```text
+orquestrador/skills/skill-react-frontend/SKILL.md
+```
+
+E atualiza automaticamente:
+
+```text
+orquestrador/SKILLS_MANIFEST.json
+orquestrador/SKILLS_ROUTER.json
+orquestrador/SKILL_ALIASES.json
+```
+
+Depois abra `orquestrador/skills/skill-react-frontend/SKILL.md` e substitua o corpo inicial por algo específico. Exemplo:
+
+```markdown
+---
+name: skill-react-frontend
+description: Use for React front-end implementation and review, including component structure, hooks, state, forms, routing, accessibility, responsive layout, tests, and build verification.
+category: frontend
+risk: medium
+source: local-react-patterns
+---
+
+# React Front-End
+
+Use this skill when creating, refactoring, or reviewing React UI code.
+Prefer the existing project stack and design system before adding new libraries.
+
+## Core Workflow
+
+1. Inspect the project stack: package scripts, router, component folders, styling system, state management, test setup, and existing UI conventions.
+2. Reuse existing components, hooks, validation helpers, API clients, icons, tokens, and layout primitives before creating new abstractions.
+3. Build the smallest coherent UI slice: data loading, empty/loading/error states, form validation, responsive behavior, and accessibility labels.
+4. Keep component boundaries practical: page/container components own data orchestration; reusable components receive explicit props and avoid hidden global state.
+5. Verify with the closest available gate: typecheck, lint, unit/component tests, build, or visual inspection when the project supports it.
+
+## Guardrails
+
+- Do not introduce a new UI library, state library, CSS framework, or router unless the project already uses it or the task explicitly requires it.
+- Do not hardcode secrets, tenant IDs, user data, private URLs, or environment-specific paths in browser code.
+- Avoid `any`; use explicit props, discriminated states, or `unknown` with guards when needed.
+- Handle mobile width, keyboard navigation, focus states, text overflow, loading states, empty states, and API errors.
+- Keep visible text spelled correctly and avoid broken UTF-8/mojibake.
+
+## Verification
+
+- Run `npm run typecheck`, `npm run lint`, `npm test`, or `npm run build` when available and relevant.
+- For UI-heavy changes, inspect the screen at desktop and mobile widths when a browser tool is available.
+- Confirm no console errors, layout overlap, clipped button text, or inaccessible form controls remain.
+
+## Related Skills
+
+- `skill-frontend-ux-guardrails`
+- `skill-modern-ui-patterns`
+- `skill-open-design-ui`
+```
+
+Se a skill deve ser encadeada por outra, edite também `orquestrador/SKILL_CHAINS.json`. Por exemplo, para permitir que `skill-saas-factory` chame a skill React, adicione `skill-react-frontend` em `chains.skill-saas-factory.mayInvoke`.
+
+### Validar E Sincronizar
+
+Valide o catálogo:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-skills.ps1
+```
+
+Ou:
+
+```bash
+./scripts/validate-skills.sh
+```
+
+Se estiver atualizando a instalação local do usuário, sincronize os espelhos:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.orquestrador\sync-skills.ps1" -Apply
+```
+
+Antes de publicar o snapshot, valide o pacote público:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-public.ps1
+git diff -- .
+```
 
 ## Hooks
 
@@ -569,7 +714,7 @@ O validador público verifica:
 
 ## Documentação Principal
 
-- [docs/installation.md](docs/installation.md): instalação completa, destinos criados e troubleshooting.
+- [docs/installation.md](docs/installation.md): instalação completa, destinos criados e resolução de problemas.
 - [docs/orquestrador.md](docs/orquestrador.md): download, instalação, verificação, uso e atualização.
 - [docs/orquestrador-reference.md](docs/orquestrador-reference.md): lógica interna, roteamento, hooks, perfis, agentes, sync e verificação.
 - [docs/skill-catalog.md](docs/skill-catalog.md): catálogo das skills canônicas, Codex e comunitárias publicadas.
@@ -580,7 +725,7 @@ O validador público verifica:
 - [docs/privacy-model.md](docs/privacy-model.md): modelo de privacidade e sanitização.
 - [docs/update-flow.md](docs/update-flow.md): como atualizar este repo a partir da máquina fonte.
 
-## Troubleshooting
+## Resolução de Problemas
 
 Se a ferramenta não chamar o Orquestrador:
 

--- a/docs/skill-catalog.md
+++ b/docs/skill-catalog.md
@@ -4,6 +4,54 @@ Este catálogo é gerado a partir dos arquivos `SKILL.md` publicados no reposit�
 
 Regra de uso: escolha primeiro pelo roteador em `orquestrador/SKILLS_ROUTER.json`; abra o `SKILL.md` completo somente da skill selecionada e dos arquivos referenciados diretamente por ela.
 
+## Adicionar Skill Canônica
+
+Use o helper em vez de criar todos os registros manualmente:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\new-canonical-skill.ps1 `
+  -Name "skill-example" `
+  -Description "Use for ..." `
+  -Category "ai" `
+  -Risk "medium" `
+  -Source "local-patterns" `
+  -Trigger "example" `
+  -Alias "exemplo" `
+  -MirrorEverywhere
+```
+
+No Linux/macOS:
+
+```bash
+./scripts/new-canonical-skill.sh \
+  --name skill-example \
+  --description "Use for ..." \
+  --category ai \
+  --risk medium \
+  --source local-patterns \
+  --trigger example \
+  --alias exemplo \
+  --mirror-everywhere
+```
+
+O comando cria `orquestrador/skills/<skill>/SKILL.md` e atualiza `orquestrador/SKILLS_MANIFEST.json`, `orquestrador/SKILLS_ROUTER.json` e `orquestrador/SKILL_ALIASES.json`.
+
+Depois de editar o corpo da skill, rode:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-skills.ps1
+```
+
+ou:
+
+```bash
+./scripts/validate-skills.sh
+```
+
+Se a skill deve ser usada junto com outras, atualize `orquestrador/SKILL_CHAINS.json` manualmente e rode a validação novamente.
+
+`SKILLS_MANIFEST.json` é a fonte de verdade para skills canônicas. O campo `mirrorEverywhere` controla quais skills entram nos espelhos usados por Codex, Claude, OpenCode, Cursor, Gemini, Windsurf, Antigravity e `.agents`.
+
 ## Skills Canônicas Do Orquestrador
 
 Fonte principal editável. O sync copia essas skills para os espelhos compatíveis.

--- a/docs/update-flow.md
+++ b/docs/update-flow.md
@@ -28,6 +28,7 @@ Também é possível manter termos privados em `.local/private-terms.txt`, um po
 ## Validar
 
 ```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-skills.ps1
 powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-public.ps1
 ```
 

--- a/orquestrador/SKILLS_INDEX.md
+++ b/orquestrador/SKILLS_INDEX.md
@@ -14,6 +14,8 @@ Read these compact files before loading skill catalogs:
 
 `{{USER_HOME}}/.orquestrador\SKILL_CHAINS.json`
 
+`{{USER_HOME}}/.orquestrador\SKILLS_MANIFEST.json`
+
 Then open only the selected `SKILL.md` files and their directly referenced files.
 
 ## Canonical Skill Roots

--- a/orquestrador/SKILLS_MANIFEST.json
+++ b/orquestrador/SKILLS_MANIFEST.json
@@ -1,0 +1,226 @@
+{
+  "version": 1,
+  "purpose": "Canonical registry for Orquestrador skills. Sync scripts use mirrorEverywhere instead of hardcoded skill lists.",
+  "skills": {
+    "skill-saas-factory": {
+      "description": "Top-level SaaS construction and review workflow for dashboards, admin, Supabase, payments, security, infra, and production readiness.",
+      "category": "saas",
+      "risk": "medium",
+      "source": "local-project-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["criar saas", "novo saas", "saas factory", "dashboard saas", "admin dashboard", "painel admin", "landing saas", "pagina de login", "página de login", "cadastro saas", "sign up", "login saas", "onboarding saas", "auth saas", "assinatura", "subscription", "billing", "multi-tenant", "supabase saas", "abacatepay", "stripe", "plans", "planos", "entitlements", "limites"],
+      "aliases": ["criar saas", "novo saas", "saas", "landing saas", "pagina de login", "página de login", "cadastro saas", "login saas", "onboarding saas", "auth saas"],
+      "status": "canonical"
+    },
+    "skill-saas-admin-dashboard": {
+      "description": "SaaS admin dashboard and internal panel patterns for users, plans, payments, logs, metrics, settings, and onboarding.",
+      "category": "saas",
+      "risk": "medium",
+      "source": "local-project-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["admin panel", "painel administrativo", "dashboard administrativo", "users admin", "pagamentos admin", "planos admin", "logs admin", "sidebar admin", "metrics dashboard"],
+      "aliases": ["dashboard", "painel admin", "admin"],
+      "status": "canonical"
+    },
+    "skill-abacatepay-integration": {
+      "description": "AbacatePay PIX/card billing, CPF/CNPJ, BRL checkout, billing webhooks, and entitlement sync.",
+      "category": "payments",
+      "risk": "medium",
+      "source": "local-payment-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["abacatepay", "pix", "cpf", "cnpj", "billing.paid", "cobranca", "cobrança", "brl checkout", "pagamento brasileiro"],
+      "aliases": ["abacatepay", "pix", "pagamento br"],
+      "status": "canonical"
+    },
+    "skill-stripe-integration": {
+      "description": "Stripe Checkout, Billing subscriptions, customer portal, webhook verification, and SaaS entitlement sync.",
+      "category": "payments",
+      "risk": "medium",
+      "source": "local-payment-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["stripe", "stripe checkout", "stripe billing", "customer portal", "invoice.paid", "checkout.session.completed", "customer.subscription", "webhook stripe"],
+      "aliases": ["stripe", "checkout"],
+      "status": "canonical"
+    },
+    "skill-saas-core-limits": {
+      "description": "SaaS plan limits, quotas, entitlements, feature flags, trials, grace periods, and blocked account states.",
+      "category": "saas",
+      "risk": "medium",
+      "source": "local-project-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["limites saas", "entitlements", "quotas", "feature flags", "trial", "grace period", "blocked account", "plan limits", "uso do plano"],
+      "aliases": ["limites", "planos", "assinaturas"],
+      "status": "canonical"
+    },
+    "skill-saas-security-scan": {
+      "description": "Authorized local SaaS repository security scan using maintained OSS tools.",
+      "category": "security",
+      "risk": "high",
+      "source": "local-security-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["saas security scan", "sast", "secrets", "dependency audit", "repo security", "local scan"],
+      "aliases": ["security scan", "scan seguranca", "seguranca saas"],
+      "status": "canonical"
+    },
+    "skill-saas-dast-recon": {
+      "description": "Authorized staging/preview DAST and recon workflow for owned SaaS systems.",
+      "category": "security",
+      "risk": "high",
+      "source": "local-security-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["dast", "preview scan", "staging scan", "zap", "nuclei", "authorized url scan"],
+      "aliases": ["dast", "zap", "nuclei"],
+      "status": "canonical"
+    },
+    "skill-security-hooks": {
+      "description": "Git hooks and CI security gates for SaaS repositories.",
+      "category": "security",
+      "risk": "medium",
+      "source": "local-security-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["security hooks", "pre-commit", "pre-push", "ci security", "security gate"],
+      "aliases": ["hooks", "pre commit", "ci security"],
+      "status": "canonical"
+    },
+    "skill-supabase-rls": {
+      "description": "Supabase/Postgres RLS design, tenant isolation, policies, indexes, and verification.",
+      "category": "security",
+      "risk": "high",
+      "source": "local-supabase-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["supabase", "rls", "row level security", "tenant isolation", "policies", "auth.uid", "service role", "storage policies"],
+      "aliases": ["supabase", "rls", "tenant isolation"],
+      "status": "canonical"
+    },
+    "skill-ai-orchestration": {
+      "description": "Server-side AI provider orchestration, routing, budgets, fallbacks, observability, and safe key handling.",
+      "category": "ai",
+      "risk": "medium",
+      "source": "local-ai-orchestration-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["ai orchestration", "llm router", "openai", "gemini", "claude", "model fallback", "token budget", "agent routing", "ai gateway"],
+      "aliases": ["ia", "ai", "llm", "token budget"],
+      "status": "canonical"
+    },
+    "skill-multiagent-orchestration": {
+      "description": "Multiagent and subagent orchestration for splitting independent engineering work, assigning ownership, reducing token waste, and integrating results safely.",
+      "category": "orchestration",
+      "risk": "medium",
+      "source": "local-orchestration-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["multiagent", "multiagents", "subagent", "subagents", "multi agente", "multi agentes", "agentes paralelos", "parallel agents", "team execution", "swarm", "delegar", "delegacao", "delegação", "usar agentes", "use subagentes", "orquestrar agentes"],
+      "aliases": ["multiagent", "multiagents", "subagent", "subagents", "agentes paralelos", "team execution", "swarm", "delegar", "orquestrar agentes"],
+      "status": "canonical"
+    },
+    "skill-aionui-cowork-orchestration": {
+      "description": "Safe AionUi cowork/team integration around Codex, Claude, Gemini, OpenCode, MCPs, and the user orchestrator without replacing the existing workflow.",
+      "category": "orchestration",
+      "risk": "medium",
+      "source": "local-orchestration-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["aionui", "aion ui", "cowork app", "cowork agents", "team mode", "aionui team", "aionui codex", "aionui claude", "aionui gemini", "aionui opencode", "mcp unified management", "agent cowork", "multi-agent cowork"],
+      "aliases": ["aionui", "aion ui", "cowork app", "team mode", "aionui team", "multi-agent cowork", "mcp unified management"],
+      "status": "canonical"
+    },
+    "skill-evolution-api": {
+      "description": "Evolution API WhatsApp integration with webhook idempotency, queueing, consent, and rate limits.",
+      "category": "communication",
+      "risk": "medium",
+      "source": "local-integration-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["evolution api", "whatsapp", "zap", "webhook whatsapp", "instancia whatsapp", "qr code whatsapp", "mensagens whatsapp"],
+      "aliases": ["whatsapp", "evolution api"],
+      "status": "canonical"
+    },
+    "skill-frontend-ux-guardrails": {
+      "description": "Frontend UX quality gates for responsive layouts, overflow, accessibility, and dashboard ergonomics.",
+      "category": "frontend",
+      "risk": "medium",
+      "source": "local-frontend-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["ux guardrails", "frontend polish", "responsive", "overflow", "layout quebrado", "dashboard ux", "accessibility", "a11y"],
+      "aliases": ["ux", "responsivo", "mobile quebrado"],
+      "status": "canonical"
+    },
+    "skill-modern-ui-patterns": {
+      "description": "Modern SaaS UI composition, compact admin surfaces, component behavior, and polished interaction states.",
+      "category": "frontend",
+      "risk": "low",
+      "source": "local-frontend-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["modern ui", "ui patterns", "componentes", "design system", "saas ui", "admin ui", "layout moderno"],
+      "aliases": ["ui moderna", "design system"],
+      "status": "canonical"
+    },
+    "skill-open-design-ui": {
+      "description": "Open-design UI workflow for product screens, design tokens, components, and visual QA.",
+      "category": "frontend",
+      "risk": "low",
+      "source": "local-frontend-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["open design", "design tokens", "design ui", "visual qa", "component library", "brand ui"],
+      "aliases": ["open design", "visual qa"],
+      "status": "canonical"
+    },
+    "skill-live-processing": {
+      "description": "Live media processing pipeline with capture, queueing, worker state, retries, and observability.",
+      "category": "media",
+      "risk": "medium",
+      "source": "local-media-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["live processing", "processamento ao vivo", "stream processing", "live video", "fila de video", "worker de video"],
+      "aliases": ["live video", "processamento ao vivo"],
+      "status": "canonical"
+    },
+    "skill-manual-video-processing": {
+      "description": "Manual upload video processing with secure storage, validation, job states, and retryable workers.",
+      "category": "media",
+      "risk": "medium",
+      "source": "local-media-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["manual video", "upload video", "processar video", "video processing", "transcode", "jobs de video"],
+      "aliases": ["upload video", "processar video"],
+      "status": "canonical"
+    },
+    "skill-smart-clip-detection": {
+      "description": "Smart clip candidate detection for video/audio using scored moments, metadata, and review workflows.",
+      "category": "media",
+      "risk": "medium",
+      "source": "local-media-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["clip detection", "detectar cortes", "smart clips", "highlight detection", "viral clips", "recortar video"],
+      "aliases": ["clips", "cortes"],
+      "status": "canonical"
+    },
+    "skill-unified-analytics": {
+      "description": "Unified SaaS/product analytics event taxonomy, metrics, funnels, dashboards, and privacy guardrails.",
+      "category": "analytics",
+      "risk": "medium",
+      "source": "local-analytics-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["analytics", "event tracking", "metrics", "funnels", "dashboard metrics", "kpis", "telemetria"],
+      "aliases": ["analytics", "metricas", "event tracking"],
+      "status": "canonical"
+    },
+    "skill-elevenlabs-voice-cloning": {
+      "description": "ElevenLabs voice generation/cloning integration with consent, asset handling, and server-side API use.",
+      "category": "ai",
+      "risk": "high",
+      "source": "local-ai-orchestration-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["elevenlabs", "voice cloning", "clonar voz", "tts", "text to speech", "voice generation"],
+      "aliases": ["elevenlabs", "voz"],
+      "status": "canonical"
+    },
+    "skill-google-workspace-sync": {
+      "description": "Google Workspace sync patterns for Drive/Sheets/Calendar data, OAuth scopes, webhooks, and reconciliation.",
+      "category": "integrations",
+      "risk": "medium",
+      "source": "local-integration-patterns",
+      "mirrorEverywhere": true,
+      "triggers": ["google workspace", "google drive", "google sheets", "google calendar", "workspace sync", "oauth google"],
+      "aliases": ["google workspace", "google calendar", "meet"],
+      "status": "canonical"
+    }
+  }
+}

--- a/orquestrador/SKILLS_ORGANIZATION.md
+++ b/orquestrador/SKILLS_ORGANIZATION.md
@@ -6,6 +6,7 @@ Use this as the operating model for shared local skills.
 
 - `{{USER_HOME}}/.orquestrador\skills` is the canonical source for custom skills.
 - `{{USER_HOME}}/.orquestrador\SKILLS_ROUTER.json` is the first file agents should read.
+- `{{USER_HOME}}/.orquestrador\SKILLS_MANIFEST.json` is the canonical registry for managed skills and sync behavior.
 - `{{USER_HOME}}/.orquestrador\SKILL_ALIASES.json` maps user wording to canonical skill names.
 - `{{USER_HOME}}/.orquestrador\SKILL_CHAINS.json` controls which skills may be chained together.
 - `{{USER_HOME}}/.orquestrador\SKILL_EXECUTION_PROFILES.json` controls max skill loading and validation depth.
@@ -69,13 +70,26 @@ Refresh security and SaaS skills against primary sources:
 
 ## Improvement Workflow
 
-1. Edit canonical skill in `.orquestrador\skills`.
-2. Update `SKILLS_ROUTER.json` if the triggers changed.
-3. Add the skill to `$mustHave` in `sync-skills.ps1` only if it should be mirrored everywhere.
-4. Run:
+1. Create the canonical skill with the helper when possible:
+
+`powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\new-canonical-skill.ps1 -Name "skill-example" -Description "Use for ..." -Category "ai" -Risk "medium" -Trigger "example" -Alias "exemplo" -MirrorEverywhere`
+
+2. Edit the generated `SKILL.md` and keep the body compact.
+3. Update `SKILL_CHAINS.json` only when the new skill should be chained by existing skills.
+4. Run the catalog validation:
+
+`powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-skills.ps1`
+
+5. Sync mirrored roots:
 
 `powershell -NoProfile -ExecutionPolicy Bypass -File {{USER_HOME}}/.orquestrador\sync-skills.ps1 -Apply`
 
-5. Run:
+6. Run:
 
 `powershell -NoProfile -ExecutionPolicy Bypass -File {{USER_HOME}}/.orquestrador\doctor.ps1`
+
+7. Before publishing the snapshot, run:
+
+`powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\validate-public.ps1`
+
+The `mirrorEverywhere` field in `SKILLS_MANIFEST.json` controls whether `sync-skills.ps1` and `sync-skills.sh` copy a skill into Codex, Claude, OpenCode, Cursor, Gemini, Windsurf, Antigravity, and legacy compatibility roots.

--- a/orquestrador/sync-skills.ps1
+++ b/orquestrador/sync-skills.ps1
@@ -28,30 +28,41 @@ $targets = @(
   (Join-Path $HomePath ".antigravity-skills\skills")
 )
 
-$mustHave = @(
-  "skill-saas-factory",
-  "skill-saas-admin-dashboard",
-  "skill-abacatepay-integration",
-  "skill-stripe-integration",
-  "skill-saas-core-limits",
-  "skill-supabase-rls",
-  "skill-saas-security-scan",
-  "skill-saas-dast-recon",
-  "skill-security-hooks",
-  "skill-ai-orchestration",
-  "skill-multiagent-orchestration",
-  "skill-aionui-cowork-orchestration",
-  "skill-evolution-api",
-  "skill-frontend-ux-guardrails",
-  "skill-modern-ui-patterns",
-  "skill-open-design-ui",
-  "skill-live-processing",
-  "skill-manual-video-processing",
-  "skill-smart-clip-detection",
-  "skill-unified-analytics",
-  "skill-elevenlabs-voice-cloning",
-  "skill-google-workspace-sync"
-)
+$manifestPath = Join-Path $HomePath ".orquestrador\SKILLS_MANIFEST.json"
+if (Test-Path -LiteralPath $manifestPath) {
+  $manifest = Get-Content -LiteralPath $manifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+  $mustHave = @(
+    $manifest.skills.PSObject.Properties |
+      Where-Object { $_.Value.mirrorEverywhere -eq $true } |
+      ForEach-Object { $_.Name } |
+      Sort-Object
+  )
+} else {
+  $mustHave = @(
+    "skill-saas-factory",
+    "skill-saas-admin-dashboard",
+    "skill-abacatepay-integration",
+    "skill-stripe-integration",
+    "skill-saas-core-limits",
+    "skill-supabase-rls",
+    "skill-saas-security-scan",
+    "skill-saas-dast-recon",
+    "skill-security-hooks",
+    "skill-ai-orchestration",
+    "skill-multiagent-orchestration",
+    "skill-aionui-cowork-orchestration",
+    "skill-evolution-api",
+    "skill-frontend-ux-guardrails",
+    "skill-modern-ui-patterns",
+    "skill-open-design-ui",
+    "skill-live-processing",
+    "skill-manual-video-processing",
+    "skill-smart-clip-detection",
+    "skill-unified-analytics",
+    "skill-elevenlabs-voice-cloning",
+    "skill-google-workspace-sync"
+  )
+}
 
 function Get-SkillSource {
   param([string]$Name)

--- a/orquestrador/sync-skills.sh
+++ b/orquestrador/sync-skills.sh
@@ -63,30 +63,38 @@ TARGETS=(
   "$HOME_PATH/.antigravity-skills/skills"
 )
 
-MUST_HAVE=(
-  "skill-saas-factory"
-  "skill-saas-admin-dashboard"
-  "skill-abacatepay-integration"
-  "skill-stripe-integration"
-  "skill-saas-core-limits"
-  "skill-supabase-rls"
-  "skill-saas-security-scan"
-  "skill-saas-dast-recon"
-  "skill-security-hooks"
-  "skill-ai-orchestration"
-  "skill-multiagent-orchestration"
-  "skill-aionui-cowork-orchestration"
-  "skill-evolution-api"
-  "skill-frontend-ux-guardrails"
-  "skill-modern-ui-patterns"
-  "skill-open-design-ui"
-  "skill-live-processing"
-  "skill-manual-video-processing"
-  "skill-smart-clip-detection"
-  "skill-unified-analytics"
-  "skill-elevenlabs-voice-cloning"
-  "skill-google-workspace-sync"
-)
+MANIFEST="$HOME_PATH/.orquestrador/SKILLS_MANIFEST.json"
+if [ -f "$MANIFEST" ] && command -v node >/dev/null 2>&1; then
+  MUST_HAVE=()
+  while IFS= read -r skill_name; do
+    [ -n "$skill_name" ] && MUST_HAVE+=("$skill_name")
+  done < <(node -e 'const fs=require("fs"); const manifest=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); for (const [name, entry] of Object.entries(manifest.skills || {}).sort()) { if (entry.mirrorEverywhere) console.log(name); }' "$MANIFEST")
+else
+  MUST_HAVE=(
+    "skill-saas-factory"
+    "skill-saas-admin-dashboard"
+    "skill-abacatepay-integration"
+    "skill-stripe-integration"
+    "skill-saas-core-limits"
+    "skill-supabase-rls"
+    "skill-saas-security-scan"
+    "skill-saas-dast-recon"
+    "skill-security-hooks"
+    "skill-ai-orchestration"
+    "skill-multiagent-orchestration"
+    "skill-aionui-cowork-orchestration"
+    "skill-evolution-api"
+    "skill-frontend-ux-guardrails"
+    "skill-modern-ui-patterns"
+    "skill-open-design-ui"
+    "skill-live-processing"
+    "skill-manual-video-processing"
+    "skill-smart-clip-detection"
+    "skill-unified-analytics"
+    "skill-elevenlabs-voice-cloning"
+    "skill-google-workspace-sync"
+  )
+fi
 
 get_skill_source() {
   local name="$1"

--- a/scripts/new-canonical-skill.ps1
+++ b/scripts/new-canonical-skill.ps1
@@ -1,0 +1,30 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$Name,
+  [Parameter(Mandatory = $true)][string]$Description,
+  [Parameter(Mandatory = $true)][string]$Category,
+  [Parameter(Mandatory = $true)][string]$Risk,
+  [string]$Source = "local-patterns",
+  [string[]]$Trigger = @(),
+  [string[]]$Alias = @(),
+  [switch]$MirrorEverywhere
+)
+
+$ErrorActionPreference = "Stop"
+$script = Join-Path $PSScriptRoot "skill-catalog.js"
+
+$argsList = @(
+  $script,
+  "new",
+  "--name", $Name,
+  "--description", $Description,
+  "--category", $Category,
+  "--risk", $Risk,
+  "--source", $Source
+)
+foreach ($item in $Trigger) { $argsList += @("--trigger", $item) }
+foreach ($item in $Alias) { $argsList += @("--alias", $item) }
+if ($MirrorEverywhere) { $argsList += "--mirror-everywhere" }
+
+& node @argsList
+exit $LASTEXITCODE

--- a/scripts/new-canonical-skill.sh
+++ b/scripts/new-canonical-skill.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+node "$SCRIPT_DIR/skill-catalog.js" new "$@"

--- a/scripts/skill-catalog.js
+++ b/scripts/skill-catalog.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const orchestratorRoot = path.join(repoRoot, "orquestrador");
+const skillsRoot = path.join(orchestratorRoot, "skills");
+const manifestPath = path.join(orchestratorRoot, "SKILLS_MANIFEST.json");
+const routerPath = path.join(orchestratorRoot, "SKILLS_ROUTER.json");
+const aliasesPath = path.join(orchestratorRoot, "SKILL_ALIASES.json");
+const chainsPath = path.join(orchestratorRoot, "SKILL_CHAINS.json");
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      args._.push(arg);
+      continue;
+    }
+    const key = arg.slice(2);
+    if (key === "mirror-everywhere") {
+      args.mirrorEverywhere = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    index++;
+    if (key === "trigger" || key === "alias") {
+      args[key] = args[key] || [];
+      args[key].push(value);
+    } else {
+      args[key] = value;
+    }
+  }
+  return args;
+}
+
+function normalizeSkillName(name) {
+  return String(name || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\/?skill:/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function assertSkillName(name) {
+  if (!/^skill-[a-z0-9][a-z0-9-]{0,58}[a-z0-9]$/.test(name)) {
+    throw new Error(`Invalid skill name: ${name}. Use skill-<lowercase-hyphen-name>, max 64 chars.`);
+  }
+}
+
+function unique(values) {
+  return Array.from(new Set((values || []).map((value) => String(value).trim()).filter(Boolean)));
+}
+
+function readFrontmatter(skillFile) {
+  const text = fs.readFileSync(skillFile, "utf8");
+  const match = text.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) return {};
+  const result = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const pair = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (!pair) continue;
+    result[pair[1]] = pair[2].trim().replace(/^["']|["']$/g, "");
+  }
+  return result;
+}
+
+function createSkill(args) {
+  const name = normalizeSkillName(args.name);
+  assertSkillName(name);
+
+  const description = String(args.description || "").trim();
+  const category = String(args.category || "").trim();
+  const risk = String(args.risk || "").trim();
+  const source = String(args.source || "local-patterns").trim();
+  const triggers = unique(args.trigger);
+  const aliases = unique(args.alias);
+
+  if (!description || !category || !risk) {
+    throw new Error("--description, --category, and --risk are required.");
+  }
+  if (triggers.length === 0) {
+    throw new Error("At least one --trigger is required.");
+  }
+
+  const skillDir = path.join(skillsRoot, name);
+  const skillFile = path.join(skillDir, "SKILL.md");
+  if (fs.existsSync(skillFile)) {
+    throw new Error(`Skill already exists: ${skillFile}`);
+  }
+
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    skillFile,
+    `---\nname: ${name}\ndescription: ${description}\ncategory: ${category}\nrisk: ${risk}\nsource: ${source}\n---\n\n# ${name}\n\n## Core Workflow\n\n1. Identify the project context, existing patterns, and the smallest useful scope.\n2. Apply this skill only when the request matches its description or router triggers.\n3. Keep implementation details local to the target project and avoid exposing secrets or private data.\n4. Verify with the lightest meaningful command or inspection for the risk level.\n\n## Guardrails\n\n- Keep this skill compact; move long details into \`references/\` and link them from this file.\n- Do not include tokens, local paths, logs, private project names, or stale API examples.\n- Prefer project evidence over generic assumptions.\n\n## Verification\n\n- Confirm the requested behavior or decision is covered by local evidence.\n- Run the relevant project validation gate when code, config, or operational behavior changes.\n\n## Related Skills\n\n- None yet.\n`,
+    "utf8"
+  );
+
+  const manifest = fs.existsSync(manifestPath)
+    ? readJson(manifestPath)
+    : { version: 1, purpose: "Canonical Orquestrador skill registry.", skills: {} };
+  manifest.skills[name] = {
+    description,
+    category,
+    risk,
+    source,
+    mirrorEverywhere: Boolean(args.mirrorEverywhere),
+    triggers,
+    aliases,
+    status: "canonical",
+  };
+  writeJson(manifestPath, manifest);
+
+  const router = readJson(routerPath);
+  router.skills[name] = {
+    description,
+    triggers,
+    canonicalPath: `{{USER_HOME}}/.orquestrador/skills/${name}/SKILL.md`,
+    codexPath: `{{USER_HOME}}/.codex/skills/${name}/SKILL.md`,
+    cost: risk === "high" ? "high" : risk === "medium" ? "medium" : "low",
+    safety: "task-specific-guardrails",
+  };
+  writeJson(routerPath, router);
+
+  const aliasDoc = readJson(aliasesPath);
+  for (const alias of aliases) {
+    aliasDoc.aliases[alias] = name;
+  }
+  writeJson(aliasesPath, aliasDoc);
+
+  console.log(`Created ${path.relative(repoRoot, skillFile)}`);
+  console.log(`Updated ${path.relative(repoRoot, manifestPath)}, SKILLS_ROUTER.json, and SKILL_ALIASES.json`);
+}
+
+function validate() {
+  const issues = [];
+  const manifest = readJson(manifestPath);
+  const router = readJson(routerPath);
+  const aliases = readJson(aliasesPath);
+  const chains = readJson(chainsPath);
+  const manifestSkills = manifest.skills || {};
+  const routerSkills = router.skills || {};
+
+  for (const [name, entry] of Object.entries(manifestSkills)) {
+    if (normalizeSkillName(name) !== name) issues.push(`manifest:${name}: name is not normalized`);
+    try {
+      assertSkillName(name);
+    } catch (error) {
+      issues.push(`manifest:${name}: ${error.message}`);
+    }
+    for (const field of ["description", "category", "risk", "source", "status"]) {
+      if (!entry[field]) issues.push(`manifest:${name}: missing ${field}`);
+    }
+
+    const skillFile = path.join(skillsRoot, name, "SKILL.md");
+    if (!fs.existsSync(skillFile)) {
+      issues.push(`skills/${name}: missing SKILL.md`);
+      continue;
+    }
+    const text = fs.readFileSync(skillFile, "utf8");
+    const frontmatter = readFrontmatter(skillFile);
+    for (const field of ["name", "description", "category", "risk", "source"]) {
+      if (!frontmatter[field]) issues.push(`skills/${name}/SKILL.md: missing frontmatter ${field}`);
+    }
+    if (frontmatter.name && frontmatter.name !== name) {
+      issues.push(`skills/${name}/SKILL.md: frontmatter name does not match directory`);
+    }
+    if (/\b(TODO|FIXME|stub|placeholder)\b/i.test(text)) {
+      issues.push(`skills/${name}/SKILL.md: contains TODO/FIXME/stub/placeholder text`);
+    }
+    if (/[ÃÂâ][\s\S]{0,2}/.test(text)) {
+      issues.push(`skills/${name}/SKILL.md: possible mojibake`);
+    }
+    if (!routerSkills[name]) issues.push(`router:${name}: missing router entry`);
+  }
+
+  for (const dirent of fs.readdirSync(skillsRoot, { withFileTypes: true })) {
+    if (!dirent.isDirectory()) continue;
+    const name = dirent.name;
+    if (!fs.existsSync(path.join(skillsRoot, name, "SKILL.md"))) continue;
+    if (!manifestSkills[name]) issues.push(`manifest:${name}: skill directory is not registered`);
+  }
+
+  for (const [name, entry] of Object.entries(routerSkills)) {
+    if (!manifestSkills[name]) issues.push(`router:${name}: no manifest entry`);
+    for (const field of ["description", "triggers", "canonicalPath", "codexPath", "cost", "safety"]) {
+      if (!entry[field]) issues.push(`router:${name}: missing ${field}`);
+    }
+    if (!Array.isArray(entry.triggers) || entry.triggers.length === 0) {
+      issues.push(`router:${name}: triggers must be a non-empty array`);
+    }
+  }
+
+  for (const [alias, skill] of Object.entries(aliases.aliases || {})) {
+    if (!manifestSkills[skill]) issues.push(`aliases:${alias}: points to missing skill ${skill}`);
+  }
+
+  for (const [skill, chain] of Object.entries(chains.chains || {})) {
+    if (!manifestSkills[skill]) issues.push(`chains:${skill}: chain owner is not in manifest`);
+    for (const target of chain.mayInvoke || []) {
+      if (!manifestSkills[target]) issues.push(`chains:${skill}: mayInvoke points to missing skill ${target}`);
+    }
+  }
+
+  if (issues.length > 0) {
+    console.error("Skill validation failed:");
+    for (const issue of issues.sort()) console.error(`  - ${issue}`);
+    process.exit(1);
+  }
+  console.log(`Skill validation passed. Skills: ${Object.keys(manifestSkills).length}`);
+}
+
+function printMirrorEverywhere() {
+  const manifest = readJson(manifestPath);
+  for (const [name, entry] of Object.entries(manifest.skills || {})) {
+    if (entry.mirrorEverywhere) console.log(name);
+  }
+}
+
+const [command, ...rest] = process.argv.slice(2);
+try {
+  if (command === "new") createSkill(parseArgs(rest));
+  else if (command === "validate") validate();
+  else if (command === "mirror-everywhere") printMirrorEverywhere();
+  else {
+    console.error("Usage: skill-catalog.js <new|validate|mirror-everywhere> [options]");
+    process.exit(2);
+  }
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}

--- a/scripts/validate-skills.ps1
+++ b/scripts/validate-skills.ps1
@@ -1,0 +1,7 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+$script = Join-Path $PSScriptRoot "skill-catalog.js"
+& node $script validate
+exit $LASTEXITCODE

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+node "$SCRIPT_DIR/skill-catalog.js" validate


### PR DESCRIPTION
- Introduced `new-canonical-skill.ps1` and `new-canonical-skill.sh` to automate the creation of canonical skills.
- Added `skill-catalog.js` for managing skills, including creation and validation functionalities.
- Updated documentation in `skill-catalog.md` and `update-flow.md` to reflect new skill creation process.
- Created `SKILLS_MANIFEST.json` to serve as a canonical registry for skills, replacing hardcoded lists in sync scripts.
- Enhanced `sync-skills.ps1` and `sync-skills.sh` to dynamically read skills from `SKILLS_MANIFEST.json`.
- Added validation scripts `validate-skills.ps1` and `validate-skills.sh` to ensure skill integrity.
- Updated `SKILLS_ORGANIZATION.md` to include new manifest and validation processes.